### PR TITLE
[lumberjack-automate] Add `cookieJar` option

### DIFF
--- a/lumberjack-automate/modules/onping.nix
+++ b/lumberjack-automate/modules/onping.nix
@@ -20,6 +20,11 @@
           type = lib.types.port;
           description = "The port OnPing is running on";
         };
+
+        cookieJar = lib.mkOption {
+          type = lib.types.path;
+          description = "Local filesystem path to cookie jar";
+        };
       };
     };
   };

--- a/lumberjack-automate/modules/scripts.nix
+++ b/lumberjack-automate/modules/scripts.nix
@@ -30,18 +30,19 @@ in
   config = lib.mkIf cfg.enable {
     driver.script =
       let
-        inherit (config.onping) host port scheme;
+        inherit (config.onping) host port scheme cookieJar;
         inherit (cfg) name path body;
       in
       pkgs.writeShellApplication {
         inherit name;
         runtimeInputs = [ pkgs.curl ];
         text = ''
-          cki="$1"
           curl -X POST \
             --fail \
+            -L \
+            -c "${cookieJar}" \
+            -b "${cookieJar}" \
             -H 'Content-Type: application/json' \
-            -H "Cookie: _SESSION=$cki" \
             ${scheme}://${host}:${builtins.toString port}/${path} \
             -d '${body}'
         '';


### PR DESCRIPTION
Related to https://github.com/plow-technologies/all/pull/11389. Rather than pass a `_SESSION` cookie around (which doesn't seem to work with OnPing over HTTPS), this switches to using Curl's cookie jar instead